### PR TITLE
Updated RequestParser

### DIFF
--- a/src/RequestParser.cpp
+++ b/src/RequestParser.cpp
@@ -1,21 +1,234 @@
+#include <cctype>
 #include <fcntl.h>
+#include <algorithm>
 #include <iostream>
 #include <sstream>
-#include <stdexcept>
 #include <string>
 #include <unistd.h>
 
 #include "RequestParser.hpp"
-#include "WebServer.hpp" // TODO: included for the global vars, probably unneccessary so remove later
+#include "Logger.hpp"
+#include "Utils.hpp"
 
 RequestParser::RequestParser()
-	: mMethod(UNKNOWN), bodyToFile(false), parsingFinished(false), bodyFd(-1),
-	  bodyExpected(0), bodyReceived(0), mHeaderEnd(0)
+	: mMethod(UNKNOWN), bodyToFile(false), parsingFinished(false), bodyFd(-1), bodyExpected(0),
+	  bodyReceived(0), mHeaderEnd(0), mParsePos(0), mClientNum(), mStatusCode(200), mState(HEADER)
 {
 }
 
 RequestParser::~RequestParser()
 {
+}
+
+bool RequestParser::parse(std::string &requestBuffer)
+{
+	std::string		  buffer;
+
+	const size_t bufSize = requestBuffer.size();
+
+	// check for new data
+	if (mParsePos >= bufSize)
+		return (true);
+
+	// check if we have a new line to parse
+	size_t lineEnd = requestBuffer.find("\r\n", mParsePos);
+	if (lineEnd == std::string::npos)
+		return (true);
+	if (mState == HEADER)
+	{
+		for (; mParsePos < requestBuffer.size(); mParsePos++)
+		{
+			if (requestBuffer[mParsePos] != '\r' && requestBuffer[mParsePos] != '\n')
+				break;
+		}
+		lineEnd = requestBuffer.find("\r\n", mParsePos);
+		mRequestHeader = requestBuffer.substr(mParsePos, lineEnd - mParsePos);
+		if (mRequestHeader.size() == 0)
+			return (true);
+		if (!parseHeader(mRequestHeader))
+			return (false);
+		mParsePos = lineEnd + 2;
+	}
+	if (mState == FIELD)
+	{
+		// now parse the header fields
+		while (42)
+		{
+			size_t next = requestBuffer.find("\r\n", mParsePos);
+			if (next == std::string::npos)
+				return (true);
+			std::string fieldLine = requestBuffer.substr(mParsePos, next - mParsePos);
+			if (fieldLine.size() == 0)
+			{
+				mState = BODY;
+				break;
+			}
+			else if (parseHeaderField(fieldLine) == false)
+				return (false);
+			mParsePos = next + 2;
+		}
+	}
+	if (mState == BODY)
+	{
+		if (mMethod != POST)
+		{
+			mState = DONE;
+			parsingFinished = true;
+			requestBuffer.erase(0, mParsePos + this->getContentLength() + 2);
+			LOG_NOTICE(std::string("request parsed: ") + mRequestHeader);
+			return (true);
+		}
+		if (parseBody(requestBuffer) == false)
+			return (false);
+	}
+	requestBuffer.erase(0, mParsePos);
+	mParsePos = 0;
+	return (true);
+}
+
+bool RequestParser::parseHeader(const std::string &header)
+{
+	// extract method
+	int methodEnd = header.find_first_of(' ', 0);
+	setMethod(header.substr(0, methodEnd));
+	if (mMethod == UNKNOWN)
+		return (false);
+
+	// extract uri
+	int uriEnd = header.find_first_of(' ', methodEnd + 1);
+	if (uriEnd == std::string::npos)
+		return (false);
+	mRequestUri = header.substr(methodEnd + 1, uriEnd - methodEnd - 1);
+	if (validateUri(mRequestUri) == false)
+		return (false);
+
+	// extract version
+	int versionEnd = header.find_first_of('\r', uriEnd + 1);
+	mHttpVersion = header.substr(uriEnd + 1, 8);
+	if (mHttpVersion != "HTTP/1.1" && mHttpVersion != "HTTP/1.0")
+		return (false);
+
+	// advance state
+	mState = FIELD;
+	return (true);
+}
+
+bool RequestParser::parseHeaderField(std::string &buffer)
+{
+	size_t colonPos = buffer.find(':');
+	if (colonPos == std::string::npos)
+		return (true);
+
+	std::string rawFieldName = buffer.substr(0, colonPos);
+	size_t		firstChar = rawFieldName.find_first_not_of(" \t");
+	size_t		lastChar = colonPos;
+	if (firstChar == colonPos)
+		return (false);
+
+	std::string fieldName = rawFieldName.substr(firstChar, lastChar - firstChar);
+	if (fieldName.find_first_of(" \t") != std::string::npos)
+		return (false);
+	for (std::string::iterator it = fieldName.begin(); it != fieldName.end(); it++)
+	{
+		*it = std::tolower(static_cast<unsigned char>(*it));
+	}
+
+	size_t fieldValueStart = buffer.find_first_not_of(" \t", colonPos + 1);
+	size_t fieldValueEnd = buffer.find_last_not_of("\r\n");
+	if (fieldValueStart == std::string::npos || fieldValueStart >= fieldValueEnd)
+		mHeaderField[fieldName] = "";
+	else
+		mHeaderField[fieldName] =
+			buffer.substr(fieldValueStart, fieldValueEnd - fieldValueStart + 1);
+	return (true);
+}
+
+bool RequestParser::parseBody(std::string &request)
+{
+	size_t contentLength = this->getContentLength();
+	size_t bodyStart = mParsePos + 4;
+
+	// init vars, triggered on first call
+	if (bodyExpected == 0 && contentLength > 0)
+	{
+		bodyExpected = contentLength;
+		bodyReceived = 0;
+		bodyToFile = false;
+		bodyFd = -1;
+		std::string tempFile;
+
+		// TODO: change tempFile so that you're writing directly to POST location (after checking
+		// uri and location is valid)
+		tempFile = "client_" + numToString(mClientNum) + ".tmp";
+		int flags = O_WRONLY | O_CREAT | O_TRUNC;
+		bodyFd = open(tempFile.c_str(), flags, 0644);
+		if (bodyFd < 0)
+			return (false);
+		setNonBlockingFlag(bodyFd);
+	}
+
+	// no expected body, set parsing as finished
+	if (bodyExpected == 0)
+	{
+		parsingFinished = true;
+		return true;
+	}
+
+	size_t available = 0;
+	if (request.size() > bodyStart + bodyReceived)
+		available = request.size() - (bodyStart + bodyReceived);
+	if (available)
+	{
+		size_t toWrite = std::min(available, bodyExpected - bodyReceived);
+		ssize_t bytesWritten = write(bodyFd, request.data() + bodyStart + bodyReceived, toWrite);
+		if (bytesWritten < 0)
+			return (false);
+		bodyReceived += static_cast<size_t>(bytesWritten);
+		mParsePos = bodyStart + bytesWritten;
+	}
+
+	if (bodyReceived >= bodyExpected)
+	{
+		parsingFinished = true;
+		mState = DONE;
+	}
+	return true;
+}
+
+/**
+	\brief extremely minimalist URI parser.
+
+	Simply looks for '/' as the first character or "http://" at the beginning.
+*/
+bool RequestParser::validateUri(const std::string &uri)
+{
+	std::string::const_iterator i = uri.begin();
+
+	if (*i == '/')
+		return (true);
+	else if (uri.find("http://", 0, 7) != std::string::npos)
+	{
+		mRequestUri = mRequestUri.substr(6);
+		return (true);
+	}
+	return (false);
+}
+
+// TODO: optional: http1.1 also supports a keep-alive header field, where client
+// can specify how many further requests to accept before closing
+int RequestParser::keepAlive()
+{
+	if (*(mHttpVersion.rbegin()) == '0')
+		return (0);
+	if (mHeaderField.find("connection") != mHeaderField.end())
+	{
+		if (mHeaderField["connection"] == "keep-alive")
+		{
+			mHeaderField.erase("connection");
+			return 1;
+		}
+	}
+	return 0;
 }
 
 void RequestParser::reset()
@@ -27,47 +240,22 @@ void RequestParser::reset()
 	bodyExpected = 0;
 	bodyReceived = 0;
 	mHeaderEnd = 0;
+	mParsePos = 0;
 	mRequestUri.clear();
 	mHttpVersion.clear();
 	mHeaderField.clear();
-}
-
-void RequestParser::setMethod(const std::string &methodStr)
-{
-	if (methodStr == "GET")
-	{
-		mMethod = GET;
-	}
-	else if (methodStr == "HEAD")
-	{
-		mMethod = HEAD;
-	}
-	else if (methodStr == "POST")
-	{
-		mMethod = POST;
-	}
+	mState = HEADER;
 }
 
 size_t RequestParser::getContentLength()
 {
 	size_t result;
-	if (mMethod == GET || mMethod == HEAD)
+
+	if (mHeaderField.find("content-length") != mHeaderField.end())
 	{
-		return 0;
-	}
-	else if (mMethod == POST)
-	{
-		if (mHeaderField.find("Content-Length") != mHeaderField.end())
-		{
-			std::stringstream lengthStream(mHeaderField["Content-Length"]);
-			lengthStream >> result;
-			if (result > MAX_BODY_IN_MEM)
-			{
-				// TODO: content length is too long, idk, throw an exception or
-				// something
-			}
-			return result;
-		}
+		std::stringstream lengthStream(mHeaderField["content-length"]);
+		lengthStream >> result;
+		return result;
 	}
 	return 0;
 }
@@ -87,20 +275,9 @@ std::map<std::string, std::string> &RequestParser::getHeaders()
 	return this->mHeaderField;
 }
 
-bool RequestParser::getParsingFinished()
+bool RequestParser::getParsingFinished() const
 {
 	return this->parsingFinished;
-}
-
-void RequestParser::parseHeader(const std::string &header)
-{
-	std::istringstream headerStream(header);
-	std::string methodStr;
-
-	headerStream >> methodStr;
-	setMethod(methodStr);
-	headerStream >> mRequestUri;
-	headerStream >> mHttpVersion;
 }
 
 void RequestParser::setHeaderEnd(const size_t &headerEnd)
@@ -108,158 +285,18 @@ void RequestParser::setHeaderEnd(const size_t &headerEnd)
 	this->mHeaderEnd = headerEnd;
 }
 
-void RequestParser::setParsingFinished(const bool &status)
+void RequestParser::setMethod(const std::string &methodStr)
 {
-	this->parsingFinished = status;
-}
-
-void RequestParser::parse(const std::string &requestBuffer)
-{
-	std::stringstream inf(requestBuffer);
-	std::string buffer;
-
-	// parse the header line on its own
-	std::getline(inf, buffer);
-	if (buffer.empty())
+	if (methodStr == "GET")
 	{
-		throw(std::runtime_error("Error: requestParser: file not found"));
+		mMethod = GET;
 	}
-	parseHeader(buffer);
-
-	// now parse the header fields
-	for (; std::getline(inf, buffer);)
+	else if (methodStr == "HEAD")
 	{
-		if (buffer.empty() || buffer == "\r")
-		{
-			break;
-		}
-
-		size_t colonPos = buffer.find(':');
-		if (colonPos == std::string::npos)
-		{
-			throw std::runtime_error(
-				"Header line is missing a colon separator.");
-		}
-
-		std::string rawFieldName = buffer.substr(0, colonPos);
-		size_t firstChar = rawFieldName.find_first_not_of(" \t");
-		size_t lastChar = rawFieldName.find_last_not_of(" \t");
-		if (firstChar == std::string::npos)
-		{
-			throw std::runtime_error("Field name is empty or only whitespace.");
-		}
-
-		std::string fieldName =
-			rawFieldName.substr(firstChar, lastChar - firstChar + 1);
-		if (fieldName.find_first_of(" \t") != std::string::npos)
-		{
-			throw std::runtime_error("Field name contains whitespace");
-		}
-		// std::cout << "Field name: " << fieldName << "." << std::endl;
-
-		size_t fieldValueStart = buffer.find_first_not_of(" \t", colonPos + 1);
-		size_t fieldValueEnd = buffer.find_last_not_of("\r\n");
-		std::string fieldValue;
-		if (fieldValueStart == std::string::npos)
-		{
-			fieldValue = "";
-		}
-		else
-		{
-			fieldValue = buffer.substr(fieldValueStart,
-			                           fieldValueEnd - fieldValueStart + 1);
-		}
-		mHeaderField[fieldName] = fieldValue;
-		// std::cout << fieldName << " = " << fieldValue << "." << std::endl;
-		// yet another TODO: header fields names are case insensitive
-		// apparently.
+		mMethod = HEAD;
 	}
-}
-
-bool RequestParser::parseBody(std::string &request)
-{
-	size_t contentLength = this->getContentLength();
-
-	// init vars, triggered on first call
-	if (bodyExpected == 0 && contentLength > 0)
+	else if (methodStr == "POST")
 	{
-		bodyExpected = contentLength;
-		bodyReceived = 0;
-		bodyToFile = false;
-		bodyFd = -1;
+		mMethod = POST;
 	}
-
-	// no expected body, set parsing as finished
-	if (bodyExpected == 0)
-	{
-		parsingFinished = true;
-		return true;
-	}
-
-	// size of body, which is total request size - header size and CRLF
-	size_t bodyBufferSize = request.size() - mHeaderEnd - 4;
-
-	// check if body size is greater than what we can hold in memory
-	if (!bodyToFile && bodyReceived + bodyBufferSize > MAX_BODY_IN_MEM)
-	{
-		std::string tempFile;
-
-		tempFile = "client_" + numToString(bodyFd) + ".tmp";
-		int flags = O_WRONLY | O_CREAT | O_TRUNC;
-		int fd = open(tempFile.c_str(), flags, 0644);
-		setNonBlockingFlag(fd);
-
-		if (fd > 0)
-		{
-			bodyFd = fd;
-			bodyToFile = true;
-		}
-		else
-		{
-			// TODO: handle this error better
-			// wrap it in an exception, or simply close the client
-			// connection and return
-			std::cerr << strerror(errno) << std::endl;
-		}
-	}
-
-	// write data to file or buffer
-	if (bodyToFile)
-	{
-		ssize_t bytesWritten =
-			write(bodyFd, request.data() + mHeaderEnd + 4, bodyBufferSize);
-		if (bytesWritten > 0)
-		{
-			bodyReceived += bytesWritten;
-		}
-	}
-	else
-	{
-		bodyReceived += bodyBufferSize;
-	}
-
-	// check if all data has been parsed
-	if (bodyReceived >= bodyExpected)
-	{
-		parsingFinished = true;
-		request.erase(0, mHeaderEnd + 4); // remove header plus CRLF
-
-		if (!bodyToFile)
-		{
-			request.erase(0, mHeaderEnd + 4 + bodyExpected);
-		}
-		else
-		{
-			close(bodyFd);
-			bodyFd = -1;
-		}
-
-		bodyExpected = 0;
-		bodyReceived = 0;
-		bodyToFile = false;
-		bodyFd = -1;
-
-		return true;
-	}
-	return false;
 }

--- a/src/RequestParser.hpp
+++ b/src/RequestParser.hpp
@@ -1,7 +1,9 @@
 #pragma once
 
+#include <cstddef>
 #include <iostream>
 #include <map>
+#include <string>
 
 enum RequestMethod
 {
@@ -11,6 +13,14 @@ enum RequestMethod
 	UNKNOWN,
 };
 
+enum RequestState
+{
+	HEADER,
+	FIELD,
+	BODY,
+	DONE
+};
+
 class RequestParser
 {
 public:
@@ -18,35 +28,41 @@ public:
 	~RequestParser();
 
 	std::map<std::string, std::string> &getHeaders();
-	void getRequestHeader();
-	RequestMethod getMethod();
-	std::string &getUri();
-	size_t getContentLength();
-	bool getParsingFinished();
+	void								getRequestHeader();
+	RequestMethod						getMethod();
+	std::string						   &getUri();
+	size_t								getContentLength();
+	bool								getParsingFinished() const;
+	int									keepAlive();
 
 	void setHeaderEnd(const size_t &headerEnd);
-	void setParsingFinished(const bool &status);
 
-	void parse(const std::string &requestBuffer);
+	bool parse(std::string &requestBuffer);
 	bool parseBody(std::string &request);
 
 	void reset();
 
 private:
-	void parseHeader(const std::string &header);
+	bool parseHeader(const std::string &header);
 	void setMethod(const std::string &method);
-	// void initHeaderFields();
+	bool validateUri(const std::string &uri);
+	bool parseHeaderField(std::string &buffer);
 
-	RequestMethod mMethod;
-	std::string mRequestUri;
-	std::string mHttpVersion;
+	RequestMethod					   mMethod;
+	std::string						   mRequestUri;
+	std::string						   mHttpVersion;
+	std::string						   mRequestHeader;
 	std::map<std::string, std::string> mHeaderField;
-	bool bodyToFile;
-	bool parsingFinished;
-	int bodyFd;
-	size_t bodyExpected;
-	size_t bodyReceived;
-	size_t mHeaderEnd;
+	bool							   bodyToFile;
+	bool							   parsingFinished;
+	int								   bodyFd;
+	size_t							   bodyExpected;
+	size_t							   bodyReceived;
+	size_t							   mHeaderEnd;
+	size_t							   mParsePos;
+	int								   mClientNum;
+	int								   mStatusCode;
+	RequestState					   mState;
 };
 
 // References:

--- a/src/ResponseBuilder.cpp
+++ b/src/ResponseBuilder.cpp
@@ -1,4 +1,5 @@
 #include <cerrno>
+#include <iostream>
 #include <fstream>
 #include <unistd.h>
 
@@ -53,13 +54,13 @@ void ResponseBuilder::reset()
 // a stanard header line
 std::string ResponseBuilder::buildResponse()
 {
-	std::ifstream htmlFile("test.html");
+	std::ifstream	   htmlFile("test.html");
 	std::ostringstream response;
 	std::ostringstream body;
 
 	body << htmlFile.rdbuf();
-	response << "HTTP/1.1 200 OK\nContent-Type: text/html\nContent-Length: "
-			 << body.str().size() << "\n\n"
+	response << "HTTP/1.1 200 OK\nContent-Type: text/html\nContent-Length: " << body.str().size()
+			 << "\n\n"
 			 << body.str();
 	return response.str();
 }
@@ -77,8 +78,8 @@ bool ResponseBuilder::readCgiResponse(int pipeOutFd)
 		body << buffer;
 		len = read(pipeOutFd, buffer, BUFFER_SIZE);
 	}
-	mResponse << "HTTP/1.1 200 OK\nContent-Type: text/html\nContent-Length: "
-			  << body.str().size() << "\n\n"
+	mResponse << "HTTP/1.1 200 OK\nContent-Type: text/html\nContent-Length: " << body.str().size()
+			  << "\n\n"
 			  << body.str();
 	std::cout << mResponse.str() << std::endl;
 

--- a/src/ResponseBuilder.hpp
+++ b/src/ResponseBuilder.hpp
@@ -3,7 +3,6 @@
 
 #include <cerrno>
 #include <cstring>
-#include <iostream>
 #include <sstream>
 
 class ResponseBuilder


### PR DESCRIPTION
- Request parser is more robust, works even if the request is fed to it one byte at a time
- Performs fewer string::erase, saving on performance
- Uses string::find with mParsePos instead of getline now to better handle odd inputs, like empty lines before request which are now ignored
- Parser is more strict with header line parsing, ignores request and closes connection after any mistake (like nginx from my testing)
- simplified and cleaned parseBody function for better clarity