### PR TITLE
handle server_name and max body size measurements

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -51,6 +51,8 @@
 		"random": "cpp",
 		"utility": "cpp",
 		"ranges": "cpp",
-		"span": "cpp"
+		"span": "cpp",
+		"csignal": "cpp",
+		"ctime": "cpp"
 	}
 }

--- a/default.conf
+++ b/default.conf
@@ -3,13 +3,14 @@ server {
     listen 8080;
     listen 9090;
     root /var/www/siteA;
+	server_name 42London;
     # Custom error pages
     error_page 404 /errors/404html;
     error_page 500 /errors/500html;
     error_page 403 /errors/403html;
 
     # Max request body size
-    client_max_body_size 100000000000000000000;
+    client_max_body_size 22G;
 
     # Routes (locations)
 
@@ -48,9 +49,9 @@ server {
 server {
     listen 8000;
     root /var/www/siteB;
-
+	server_name 42Paris;
     error_page 404 /siteB_errors/404html;
-    client_max_body_size 5000000000000;
+    client_max_body_size 42M;
 
     location /api {
 		return 555 http//examplecom/new;

--- a/src/configParser.hpp
+++ b/src/configParser.hpp
@@ -23,6 +23,7 @@ struct LocationConfig {
 };
 
 struct ServerConfig {
+	std::string					serverName;
 	std::string					root;
 	std::vector<int> 			listenPorts;
 	std::map<int, std::string>	errorPages;


### PR DESCRIPTION
server_name now being parsed from the config file
M, G and K now being parsed in the max client body size as like NGINX
I will proceed to split everything out into cleaner functions